### PR TITLE
feat: add new frontend-component-header-edunext with new items in header for UTEC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
-        "@edx/frontend-component-header": "npm:@edunext/frontend-component-header@5.0.2-alpha.1",
+        "@edx/frontend-component-header": "git+https://github.com/eduNEXT/frontend-component-header-edunext.git#bc/css-variables-5.0.2-utec.1",
         "@edx/frontend-platform": "npm:@edunext/frontend-platform@7.1.2-alpha.1",
         "@edx/openedx-atlas": "^0.6.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -2250,8 +2250,8 @@
     "node_modules/@edx/frontend-component-header": {
       "name": "@edunext/frontend-component-header",
       "version": "5.0.2-alpha.1",
-      "resolved": "https://registry.npmjs.org/@edunext/frontend-component-header/-/frontend-component-header-5.0.2-alpha.1.tgz",
-      "integrity": "sha512-2Y62Xjv6LHbQw6RC233j34hxkKwPKcPA1rWXG5BByEHD8MeQSYyxagMCaLVFSSqVq1EexuhL7WmAiWgMIevsiA==",
+      "resolved": "git+ssh://git@github.com/eduNEXT/frontend-component-header-edunext.git#9ea9656f80e17695584377f59e832f151141336a",
+      "license": "AGPL-3.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "6.5.1",
         "@fortawesome/free-brands-svg-icons": "6.5.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
-    "@edx/frontend-component-header": "npm:@edunext/frontend-component-header@5.0.2-alpha.1",
+    "@edx/frontend-component-header": "git+https://github.com/eduNEXT/frontend-component-header-edunext.git#bc/css-variables-5.0.2-utec.1",
     "@edx/frontend-platform": "npm:@edunext/frontend-platform@7.1.2-alpha.1",
     "@edx/openedx-atlas": "^0.6.0",
     "@fortawesome/fontawesome-svg-core": "1.2.36",


### PR DESCRIPTION
This PR updates the version of the `frontend-component-header-edunext` package used in the Account MFE to include recent customizations made for UTEC.

The specific change introduced is the addition of a new header link labeled "Acerca de EDU", which directs users to the institution’s informational page. This update ensures that the new link is rendered within the header component in the Account MFE.

The change was made directly in the `frontend-component-header-edunext` repo and published via a custom Git-based dependency. This PR integrates that update into this MFE.

## How Has This Been Tested?
- Manually verified the button is rendered correctly when the app loads.
- Confirmed the link works and redirects to the correct "About EDU" page.
- Tested language switch to ensure the label reflects the translated content (i18n).
- Checked for compatibility with other header links and UI components.

|Before|After|
|-------|-----|
No "About EDU" link in the header | New "Acerca de EDU" button visible in header

![Captura de pantalla de 2025-04-24 15-57-22](https://github.com/user-attachments/assets/f5b6c275-1ac2-402a-a9f0-6d507aded87c)
![image](https://github.com/user-attachments/assets/a9e07d66-e957-451c-aeee-d9152db9b564)


Merge Checklist
* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

Post-merge Checklist
* [ ] Deploy the changes to prod after verifying on stage or ask @openedx/edx-infinity to do it.
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.